### PR TITLE
Mesh network group video calling

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,14 @@ technology.
 <img align="right" width="400" height="auto" src="public/images/preview.gif">
 
 - Screen sharing
+- Group call with up to 4 peers
 - Picture in picture
 - Live captions
 - Text chat
 - Auto-scaling video quality
 - No download required, entirely browser based
 - Direct peer to peer connection ensures lowest latency
+- No SFU servers, group calls use mesh networks
 - Single use disposable chat rooms
 
 ## Quick start

--- a/public/chat.html
+++ b/public/chat.html
@@ -46,7 +46,8 @@
     </div>
 
     <p id="remote-video-text"></p>
-    <video id="remote-video" autoplay playsinline></video>
+    <div id="wrapper">
+    </div>
     <div id="moveable">
       <p id="local-video-text">No webcam input</p>
       <video id="local-video" autoplay muted playsinline></video>

--- a/public/chat.html
+++ b/public/chat.html
@@ -46,8 +46,7 @@
     </div>
 
     <p id="remote-video-text"></p>
-    <div id="wrapper">
-    </div>
+    <div id="wrapper"></div>
     <div id="moveable">
       <p id="local-video-text">No webcam input</p>
       <video id="local-video" autoplay muted playsinline></video>

--- a/public/css/chat.css
+++ b/public/css/chat.css
@@ -111,7 +111,9 @@ a {
 
 #wrapper {
   display: flex;
-  flex-direction: column;
+  /* flex: 1 1 20em; */
+  /* flex-basis: 30%; */
+  flex-direction: row;
   align-items: center;
   flex-wrap: wrap;
   justify-content: center;
@@ -122,8 +124,8 @@ a {
   left: 50%;
   -ms-transform: translate(-50%, -50%);
   transform: translate(-50%, -50%);
-  width: 65%;
-  max-height: 100%;
+  width: 100%;
+  max-height: 90vh;
   max-width: 100%;
 }
 
@@ -146,7 +148,7 @@ a {
 }
 #remote-video:first-child:nth-last-child(1) {
 /* -or- li:only-child { */
-  max-height: 80vh;
+width: 80vw;
 }
 
 /* two items */
@@ -415,7 +417,22 @@ button:hover {
     margin: 0;
     line-height: 2rem;
   }
-
+  #wrapper {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    flex-wrap: wrap;
+    justify-content: center;
+    padding: 0;
+    margin: 0;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    -ms-transform: translate(-50%, -50%);
+    transform: translate(-50%, calc(-50% - 3rem));
+    max-height: 90%;
+    max-width: 100%;
+  }
   #remote-video {
     /* width: 75vw;
     height: calc((16/9) * 75vw); */

--- a/public/css/chat.css
+++ b/public/css/chat.css
@@ -337,6 +337,9 @@ button:hover {
   justify-content: center;
   padding: 12px;
   max-width: 100%;
+  border-style: solid;
+  border-width: 2px;
+  border-color: var(--bloc-color);
   border-radius: 20px 20px 20px 5px;
   box-shadow: 6px 6px 12px #030506, -6px -6px 12px #23242a;
 }
@@ -345,6 +348,9 @@ button:hover {
 #chat-zone .message-item.customer .message-bloc {
   background-color: rgb(47, 48, 52);
   color: #fff;
+  border-style: solid;
+  border-width: 2px;
+  border-color: var(--bloc-color);
   border-radius: 20px 20px 5px 20px;
   box-shadow: 6px 6px 12px #030506, -6px -6px 12px #22232a;
 }

--- a/public/css/chat.css
+++ b/public/css/chat.css
@@ -145,7 +145,7 @@ a {
   padding: 10px;
 }
 #remote-video:first-child:nth-last-child(1) {
-/* -or- li:only-child { */
+  /* -or- li:only-child { */
   max-height: 80vh;
 }
 

--- a/public/css/chat.css
+++ b/public/css/chat.css
@@ -109,11 +109,26 @@ a {
   background: #16171a;
 }
 
+#wrapper {
+  display: grid;
+  grid-gap: 10px;
+  justify-content: center;
+  padding: 0;
+  margin: 0;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  -ms-transform: translate(-50%, -50%);
+  transform: translate(-50%, -50%);
+  width: 65%;
+  max-height: 100%;
+  max-width: 100%;
+}
+
 /*caption text*/
 #remote-video-text {
   box-sizing: border-box;
   margin: 0;
-  width: 65vw;
   position: absolute;
   top: calc(80%);
   left: 20vw;
@@ -131,15 +146,8 @@ a {
 #remote-video {
   padding: 0;
   margin: 0;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  -ms-transform: translate(-50%, -50%);
-  transform: translate(-50%, -50%);
-  width: 65%;
+  width: 100%;
   height: auto;
-  max-height: 100%;
-  max-width: 100%;
   border-radius: 10px;
   background-image: url(../images/loader.gif);
   background-size: 400px auto;

--- a/public/css/chat.css
+++ b/public/css/chat.css
@@ -337,6 +337,9 @@ button:hover {
   justify-content: center;
   padding: 12px;
   max-width: 100%;
+  border-style: solid;
+  border-width: 3px;
+  border-color: var(--bloc-color);
   border-radius: 20px 20px 20px 5px;
   box-shadow: 6px 6px 12px #030506, -6px -6px 12px #23242a;
 }
@@ -345,6 +348,9 @@ button:hover {
 #chat-zone .message-item.customer .message-bloc {
   background-color: rgb(47, 48, 52);
   color: #fff;
+  border-style: solid;
+  border-width: 3px;
+  border-color: var(--bloc-color);
   border-radius: 20px 20px 5px 20px;
   box-shadow: 6px 6px 12px #030506, -6px -6px 12px #22232a;
 }

--- a/public/css/chat.css
+++ b/public/css/chat.css
@@ -110,8 +110,10 @@ a {
 }
 
 #wrapper {
-  display: grid;
-  grid-gap: 10px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex-wrap: wrap;
   justify-content: center;
   padding: 0;
   margin: 0;
@@ -142,12 +144,33 @@ a {
   border-radius: 0 0 10px 10px;
   padding: 10px;
 }
+#remote-video:first-child:nth-last-child(1) {
+/* -or- li:only-child { */
+  max-height: 80vh;
+}
+
+/* two items */
+#remote-video:first-child:nth-last-child(2),
+#remote-video:first-child:nth-last-child(2) ~ #remote-video {
+  max-height: 40vh;
+}
+
+/* three items */
+#remote-video:first-child:nth-last-child(3),
+#remote-video:first-child:nth-last-child(3) ~ #remote-video {
+  max-height: 40vh;
+}
+
+/* four items */
+#remote-video:first-child:nth-last-child(4),
+#remote-video:first-child:nth-last-child(4) ~ #remote-video {
+  max-height: 40vh;
+}
 
 #remote-video {
   padding: 0;
-  margin: 0;
-  width: 100%;
-  height: auto;
+  margin: 10px;
+  width: auto;
   border-radius: 10px;
   background-image: url(../images/loader.gif);
   background-size: 400px auto;

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -204,7 +204,7 @@ var VideoChat = {
             break;
           case "disconnected":
             // First possibility: we disconnected from the peer
-            if (VideoChat.socket.connect().connected === false) {
+            if (VideoChat.socket.connected === false) {
               location.reload();
             }
 

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -835,7 +835,7 @@ function handleRecieveMessage(msg, color) {
 }
 
 function uuidToHue(uuid) {
-  // Using uuid to generate random. unique pastel color
+  // Using uuid to generate random, unique pastel color
   var hash = 0;
   for (var i = 0; i < uuid.length; i++) {
       hash = uuid.charCodeAt(i) + ((hash << 5) - hash);
@@ -854,6 +854,7 @@ function uuidToHue(uuid) {
       }
     }
   }
+  VideoChat.peerColors.set(uuid, hue);
   return hue;
 }
 
@@ -865,7 +866,6 @@ function hueToColor(hue) {
 function setStreamColor(uuid) {
   const hue = uuidToHue(uuid);
   document.querySelectorAll(`[uuid="${uuid}"]`)[0].style.border = `3px solid ${hueToColor(hue)}`;
-  VideoChat.peerColors.set(uuid, hue);
 }
 
 // Show and hide chat

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -647,7 +647,7 @@ function switchStreamHelper(stream) {
   // Update local video object
   VideoChat.localVideo.srcObject = stream;
   // Unpause video on swap
-  if (videoIsPaused) {
+  if (!VideoChat.videoEnabled) {
     pauseVideo();
   }
 }

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -139,6 +139,7 @@ var VideoChat = {
     );
     // Delete connection & metadata
     VideoChat.connected.delete(uuid);
+    VideoChat.peerConnections.get(uuid).close(); // This is necessary, because otherwise the RTC connection isn't closed
     VideoChat.peerConnections.delete(uuid);
     dataChannel.delete(uuid);
     if (VideoChat.peerConnections.size === 0) {
@@ -787,39 +788,6 @@ function recieveCaptions(captions) {
 }
 // End Live caption
 
-// Translation
-// function translate(text) {
-//   let fromLang = "en";
-//   let toLang = "zh";
-//   // let text = "hello how are you?";
-//   const API_KEY = "APIKEYHERE";
-//   let gurl = `https://translation.googleapis.com/language/translate/v2?key=${API_KEY}`;
-//   gurl += "&q=" + encodeURI(text);
-//   gurl += `&source=${fromLang}`;
-//   gurl += `&target=${toLang}`;
-//   fetch(gurl, {
-//     method: "GET",
-//     headers: {
-//       "Content-Type": "application/json",
-//       Accept: "application/json",
-//     },
-//   })
-//     .then((res) => res.json())
-//     .then((response) => {
-//       // console.log("response from google: ", response);
-//       // return response["data"]["translations"][0]["translatedText"];
-//       logIt(response);
-//       var translatedText =
-//         response["data"]["translations"][0]["translatedText"];
-//       console.log(translatedText);
-//       dataChanel.send("cap:" + translatedText);
-//     })
-//     .catch((error) => {
-//       console.log("There was an error with the translation request: ", error);
-//     });
-// }
-// End Translation
-
 // Text Chat
 // Add text message to chat screen on page
 function addMessageToScreen(msg, border, isOwnMessage) {
@@ -960,6 +928,12 @@ function displayWaitingCaption() {
   // Reposition captions on start
   rePositionCaptions();
 }
+
+window.onbeforeunload = function () {
+  VideoChat.socket.emit("leave", roomHash);
+  return null;
+};
+
 
 function startUp() {
   //  Try and detect in-app browsers and redirect

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -73,7 +73,14 @@ var VideoChat = {
   onMediaStream: function (stream) {
     logIt("onMediaStream");
     VideoChat.localStream = stream;
-    VideoChat.localAudio = stream.getAudioTracks()[0];
+
+    // We need to store the local audio track, because
+    // the screen sharing MediaStream doesn't have audio
+    // by default, which is problematic for peer C who joins
+    // while another peer A/B is screen sharing (C won't receive
+    // A/Bs audio).
+    VideoChat.localAudio = stream.getAudioTracks()[0]; 
+
     // Add the stream as video's srcObject.
     // Now that we have webcam video sorted, prompt user to share URL
     Snackbar.show({
@@ -611,6 +618,10 @@ function swap() {
         swapIcon.classList.remove("fa-desktop");
         swapIcon.classList.add("fa-camera");
         swapText.innerText = "Share Webcam";
+
+        // Add audio track to screen sharing MediaStream,
+        // in case another peer joins while screen is being
+        // shared.
         stream.addTrack(VideoChat.localAudio);
         console.log(stream);
         switchStreamHelper(stream);
@@ -622,7 +633,8 @@ function swap() {
       });
     // If mode is screenshare then switch to webcam
   } else {
-    // Stop the screen share track
+    // Stop the screen share video track. (We don't want to 
+    // stop the audio track obviously.)
     VideoChat.localVideo.srcObject.getVideoTracks().forEach((track) => track.stop());
     // Get webcam input
     navigator.mediaDevices

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -98,7 +98,7 @@ var VideoChat = {
     });
 
     VideoChat.localVideo.srcObject = stream;
-    VideoChat.localVideo.style.border = `4px solid ${VideoChat.borderColor}`;
+    VideoChat.localVideo.style.border = `3px solid ${VideoChat.borderColor}`;
 
     // Now we're ready to join the chat room.
     VideoChat.socket.emit("join", roomHash);

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -20,6 +20,7 @@ const isWebRTCSupported =
 const chatInput = document.querySelector(".compose input");
 const remoteVideoVanilla = document.getElementById("remote-video");
 const remoteVideo = $("#remote-video");
+const remoteVideosWrapper = $("#wrapper");
 const captionText = $("#remote-video-text");
 const localVideoText = $("#local-video-text");
 const captionButtontext = $("#caption-button-text");
@@ -31,7 +32,7 @@ var VideoChat = {
   willInitiateCall: false,
   localICECandidates: [],
   socket: io(),
-  remoteVideo: document.getElementById("remote-video"),
+  remoteVideoWrapper: document.getElementById("wrapper"),
   localVideo: document.getElementById("local-video"),
   recognition: undefined,
 
@@ -303,12 +304,20 @@ var VideoChat = {
   // Called when a stream is added to the peer connection
   onAddStream: function (event) {
     logIt("onAddStream <<< Received new stream from remote. Adding it...");
+    // Create new remote video source in wrapper
+    // Create a <video> node
+    var node = document.createElement("video");
+    node.setAttribute("autoplay", "");
+    node.setAttribute("playsinline", "");
+    node.setAttribute("id", "remote-video");
+    VideoChat.remoteVideoWrapper.appendChild(node);
     // Update remote video source
-    VideoChat.remoteVideo.srcObject = event.stream;
+    console.log(VideoChat.remoteVideoWrapper.children);
+    VideoChat.remoteVideoWrapper.lastChild.srcObject = event.stream;
     // Close the initial share url snackbar
     Snackbar.close();
     // Remove the loading gif from video
-    VideoChat.remoteVideo.style.background = "none";
+    VideoChat.remoteVideoWrapper.lastChild.style.background = "none";
     // Update connection status
     VideoChat.connected = true;
     // Hide caption status text
@@ -360,7 +369,7 @@ function chatRoomFull() {
 // Reposition local video to top left of remote video
 function rePositionLocalVideo() {
   // Get position of remote video
-  var bounds = remoteVideo.position();
+  var bounds = remoteVideosWrapper.position();
   let localVideo = $("#local-video");
   if (
     /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
@@ -380,9 +389,9 @@ function rePositionLocalVideo() {
 // Reposition captions to bottom of video
 function rePositionCaptions() {
   // Get remote video position
-  var bounds = remoteVideo.position();
+  var bounds = remoteVideosWrapper.position();
   bounds.top -= 10;
-  bounds.top = bounds.top + remoteVideo.height() - 1 * captionText.height();
+  bounds.top = bounds.top + remoteVideosWrapper.height() - 1 * captionText.height();
   // Reposition captions
   captionText.css(bounds);
 }

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -220,17 +220,11 @@ var VideoChat = {
             logIt("connected");
             break;
           case "disconnected":
-            // Remove UUID if connection to server is intact
-            if (VideoChat.socket.connected) {
-              VideoChat.onLeave(uuid);
-            } else {
-              location.reload();
-            }
+            // Disconnects are handled server-side
+            logIt("disconnected - UUID " + uuid);
             break;
           case "failed":
             logIt("failed");
-            // VideoChat.socket.connect
-            // VideoChat.createOffer();
             // Refresh page if connection has failed
             location.reload();
             break;
@@ -849,12 +843,12 @@ function uuidToHue(uuid) {
   }
   var hue = Math.abs(hash % 360);
   // Ensure color is not similar to other colors
-  var availColors = Array.from({length: 9}, (x,i) => i*40);
-  VideoChat.peerColors.forEach(function(value, key, map) {availColors[Math.floor(value/40)] = null});
-  if (availColors[Math.floor(hue/40)] == null) {
+  var availColors = Array.from({length: 6}, (x,i) => i*60);
+  VideoChat.peerColors.forEach(function(value, key, map) {availColors[Math.floor(value/60)] = null});
+  if (availColors[Math.floor(hue/60)] == null) {
     for (var i = 0; i < availColors.length; i++) {
       if (availColors[i] != null) {
-        hue = (hue % 40) + availColors[i];
+        hue = (hue % 60) + availColors[i];
         availColors[i] = null;
         break;
       }

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -204,7 +204,9 @@ var VideoChat = {
             break;
           case "disconnected":
             logIt("disconnected - UUID " + uuid);
-            VideoChat.remoteVideoWrapper.removeChild(document.querySelectorAll(`[uuid="${uuid}"]`)[0]);
+            VideoChat.remoteVideoWrapper.removeChild(
+              document.querySelectorAll(`[uuid="${uuid}"]`)[0]
+            );
             VideoChat.connected.delete(uuid);
             VideoChat.peerConnections.delete(uuid);
             dataChannel.delete(uuid);
@@ -225,15 +227,6 @@ var VideoChat = {
             break;
         }
       };
-
-
-      // Downscale send resolution and bitrate if num in room > 4
-      if (VideoChat.peerConnections.size > 3) {
-        for (var pc in VideoChat.peerConnections) {
-          downscaleStream(pc);
-        }
-      }
-
       callback(uuid);
     };
   },
@@ -370,6 +363,12 @@ var VideoChat = {
     VideoChat.connected.set(uuid, true);
     // Hide caption status text
     captionText.fadeOut();
+    // Downscale send resolution and bitrate if num in room > 4
+    if (VideoChat.peerConnections.size > 3) {
+      VideoChat.peerConnections.forEach(function (value, key, map) {
+        downscaleStream(value);
+      });
+    }
     // Reposition local video after a second, as there is often a delay
     // between adding a stream and the height of the video div changing
     setTimeout(() => rePositionLocalVideo(), 500);
@@ -508,16 +507,18 @@ function sendToAllDataChannels(message) {
 // }
 // End Fullscreen
 
-
 // Downscale single stream
-async function downscaleStream(pc) {
-  height = 480;
+async function downscaleStream(pc, applying = false) {
+  height = 240;
   rate = 800000;
+  if (applying) return;
   try {
+    applying = true;
     do {
       h = height;
-      r = rate;
-      const [sender] = pc.getSenders();
+      const sender = pc.getSenders().find(function (s) {
+        return s.track.kind === "video";
+      });
       const ratio = sender.track.getSettings().height / height;
       const params = sender.getParameters();
       if (!params.encodings) params.encodings = [{}]; // Firefox workaround!
@@ -527,6 +528,8 @@ async function downscaleStream(pc) {
     } while (h != height);
   } catch (e) {
     logIt(e);
+  } finally {
+    applying = false;
   }
 }
 
@@ -542,7 +545,7 @@ function muteMicrophone() {
     });
     audioTrack.enabled = VideoChat.audioEnabled;
   });
-  
+
   // select mic button and mic button text
   const micButtonIcon = document.getElementById("mic-icon");
   const micButtonText = document.getElementById("mic-text");
@@ -894,15 +897,16 @@ function uuidToColor(uuid) {
   // Using uuid to generate random. unique pastel color
   var hash = 0;
   for (var i = 0; i < uuid.length; i++) {
-      hash = uuid.charCodeAt(i) + ((hash << 5) - hash);
-      hash = hash & hash;
+    hash = uuid.charCodeAt(i) + ((hash << 5) - hash);
+    hash = hash & hash;
   }
   var hue = Math.abs(hash % 360);
-  console.log(hue);
   // Ensure color is not similar to other colors
-  var availColors = Array.from({length: 18}, (x,i) => i*20);
-  VideoChat.peerColors.forEach(function(value, key, map) {availColors[Math.floor(value/20)] = null});
-  if (availColors[Math.floor(hue/20)] == null) {
+  var availColors = Array.from({ length: 18 }, (x, i) => i * 20);
+  VideoChat.peerColors.forEach(function (value, key, map) {
+    availColors[Math.floor(value / 20)] = null;
+  });
+  if (availColors[Math.floor(hue / 20)] == null) {
     for (var i = 0; i < availColors.length; i++) {
       if (availColors[i] != null) {
         hue = (hue % 20) + availColors[i];
@@ -917,7 +921,9 @@ function uuidToColor(uuid) {
 // Sets the border color of uuid's stream
 function setStreamColor(uuid) {
   const color = uuidToColor(uuid);
-  document.querySelectorAll(`[uuid="${uuid}"]`)[0].style.border = `3px solid ${color}`;
+  document.querySelectorAll(
+    `[uuid="${uuid}"]`
+  )[0].style.border = `3px solid ${color}`;
   VideoChat.peerColors[uuid] = color;
 }
 
@@ -952,18 +958,27 @@ function togglePictureInPicture() {
         logIt("Error exiting pip.");
         logIt(error);
       });
-    } else if (VideoChat.remoteVideoWrapper.lastChild.webkitPresentationMode === "inline") {
-      VideoChat.remoteVideoWrapper.lastChild.webkitSetPresentationMode("picture-in-picture");
     } else if (
-      VideoChat.remoteVideoWrapper.lastChild.webkitPresentationMode === "picture-in-picture"
+      VideoChat.remoteVideoWrapper.lastChild.webkitPresentationMode === "inline"
     ) {
-      VideoChat.remoteVideoWrapper.lastChild.webkitSetPresentationMode("inline");
+      VideoChat.remoteVideoWrapper.lastChild.webkitSetPresentationMode(
+        "picture-in-picture"
+      );
+    } else if (
+      VideoChat.remoteVideoWrapper.lastChild.webkitPresentationMode ===
+      "picture-in-picture"
+    ) {
+      VideoChat.remoteVideoWrapper.lastChild.webkitSetPresentationMode(
+        "inline"
+      );
     } else {
-      VideoChat.remoteVideoWrapper.lastChild.requestPictureInPicture().catch((error) => {
-        alert(
-          "You must be connected to another person to enter picture in picture."
-        );
-      });
+      VideoChat.remoteVideoWrapper.lastChild
+        .requestPictureInPicture()
+        .catch((error) => {
+          alert(
+            "You must be connected to another person to enter picture in picture."
+          );
+        });
     }
   } else {
     alert(

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -499,6 +499,12 @@ function sendToAllDataChannels(message) {
 // }
 // End Fullscreen
 
+
+// Downscale own stream
+function downscaleStreams() {
+  // To be implemented
+}
+
 // Mute microphone
 function muteMicrophone() {
   var audioTrack = null;

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -98,12 +98,12 @@ var VideoChat = {
       },
     });
 
-    // VideoChat.borderColor = uuidToColor(VideoChat.socket.id);
     VideoChat.localVideo.srcObject = stream;
-    VideoChat.localVideo.style.border = `3px solid ${VideoChat.borderColor}`;
 
     // Now we're ready to join the chat room.
     VideoChat.socket.emit("join", roomHash);
+    VideoChat.borderColor = hueToColor(uuidToHue(VideoChat.socket.id));
+    VideoChat.localVideo.style.border = `3px solid ${VideoChat.borderColor}`;
 
     // Add listeners to the websocket
     VideoChat.socket.on("leave", VideoChat.onLeave);
@@ -187,7 +187,7 @@ var VideoChat = {
         const dataType = receivedData.substring(0, 4);
         const cleanedMessage = receivedData.slice(4);
         if (dataType === "mes:") {
-          handleRecieveMessage(cleanedMessage, VideoChat.peerColors[uuid]);
+          handleRecieveMessage(cleanedMessage, hueToColor(VideoChat.peerColors[uuid]));
         } else if (dataType === "cap:") {
           recieveCaptions(cleanedMessage);
         } else if (dataType === "tog:") {
@@ -839,7 +839,7 @@ function handleRecieveMessage(msg, color) {
   }
 }
 
-function uuidToColor(uuid) {
+function uuidToHue(uuid) {
   // Using uuid to generate random. unique pastel color
   var hash = 0;
   for (var i = 0; i < uuid.length; i++) {
@@ -848,25 +848,29 @@ function uuidToColor(uuid) {
   }
   var hue = Math.abs(hash % 360);
   // Ensure color is not similar to other colors
-  var availColors = Array.from({length: 18}, (x,i) => i*20);
-  VideoChat.peerColors.forEach(function(value, key, map) {availColors[Math.floor(value/20)] = null});
-  if (availColors[Math.floor(hue/20)] == null) {
+  var availColors = Array.from({length: 12}, (x,i) => i*30);
+  VideoChat.peerColors.forEach(function(value, key, map) {availColors[Math.floor(value/30)] = null});
+  if (availColors[Math.floor(hue/30)] == null) {
     for (var i = 0; i < availColors.length; i++) {
       if (availColors[i] != null) {
-        hue = (hue % 20) + availColors[i];
+        hue = (hue % 30) + availColors[i];
         availColors[i] = null;
         break;
       }
     }
   }
-  return `hsl(${hue},100%,70%)`;
+  return hue;
+}
+
+function hueToColor(hue) {
+  return `hsl(${hue},100%,70%)`
 }
 
 // Sets the border color of uuid's stream
 function setStreamColor(uuid) {
-  const color = uuidToColor(uuid);
-  document.querySelectorAll(`[uuid="${uuid}"]`)[0].style.border = `3px solid ${color}`;
-  VideoChat.peerColors[uuid] = color;
+  const hue = uuidToHue(uuid);
+  document.querySelectorAll(`[uuid="${uuid}"]`)[0].style.border = `3px solid ${hueToColor(hue)}`;
+  VideoChat.peerColors[uuid] = hue;
 }
 
 // Show and hide chat

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -188,7 +188,7 @@ var VideoChat = {
         const dataType = receivedData.substring(0, 4);
         const cleanedMessage = receivedData.slice(4);
         if (dataType === "mes:") {
-          handleRecieveMessage(cleanedMessage, hueToColor(VideoChat.peerColors[uuid]));
+          handleRecieveMessage(cleanedMessage, hueToColor(VideoChat.peerColors.get(uuid)));
         } else if (dataType === "cap:") {
           recieveCaptions(cleanedMessage);
         } else if (dataType === "tog:") {
@@ -871,7 +871,7 @@ function hueToColor(hue) {
 function setStreamColor(uuid) {
   const hue = uuidToHue(uuid);
   document.querySelectorAll(`[uuid="${uuid}"]`)[0].style.border = `3px solid ${hueToColor(hue)}`;
-  VideoChat.peerColors[uuid] = hue;
+  VideoChat.peerColors.set(uuid, hue);
 }
 
 // Show and hide chat

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -39,7 +39,7 @@ var VideoChat = {
   localVideo: document.getElementById("local-video"),
   peerConnections: new Map(),
   recognition: undefined,
-  borderColor: "hsl(120,100%,70%)",
+  borderColor: undefined,
   peerColors: new Map(),
 
   // Call to getUserMedia (provided by adapter.js for cross browser compatibility)
@@ -101,9 +101,10 @@ var VideoChat = {
     VideoChat.localVideo.srcObject = stream;
 
     // Now we're ready to join the chat room.
-    VideoChat.socket.emit("join", roomHash);
-    VideoChat.borderColor = hueToColor(uuidToHue(VideoChat.socket.id));
-    VideoChat.localVideo.style.border = `3px solid ${VideoChat.borderColor}`;
+    VideoChat.socket.emit("join", roomHash, function() {
+      VideoChat.borderColor = hueToColor(uuidToHue(VideoChat.socket.id));
+      VideoChat.localVideo.style.border = `3px solid ${VideoChat.borderColor}`;
+    });
 
     // Add listeners to the websocket
     VideoChat.socket.on("leave", VideoChat.onLeave);
@@ -848,12 +849,12 @@ function uuidToHue(uuid) {
   }
   var hue = Math.abs(hash % 360);
   // Ensure color is not similar to other colors
-  var availColors = Array.from({length: 12}, (x,i) => i*30);
-  VideoChat.peerColors.forEach(function(value, key, map) {availColors[Math.floor(value/30)] = null});
-  if (availColors[Math.floor(hue/30)] == null) {
+  var availColors = Array.from({length: 9}, (x,i) => i*40);
+  VideoChat.peerColors.forEach(function(value, key, map) {availColors[Math.floor(value/40)] = null});
+  if (availColors[Math.floor(hue/40)] == null) {
     for (var i = 0; i < availColors.length; i++) {
       if (availColors[i] != null) {
-        hue = (hue % 30) + availColors[i];
+        hue = (hue % 40) + availColors[i];
         availColors[i] = null;
         break;
       }

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -183,8 +183,8 @@ var VideoChat = {
           case "connected":
             logIt("connected");
             // Once connected we no longer have a need for the signaling server, so disconnect
-            VideoChat.socket.off("token");
-            VideoChat.socket.off("offer");
+            // VideoChat.socket.off("token");
+            // VideoChat.socket.off("offer");
             break;
           case "disconnected":
             logIt("disconnected");
@@ -308,13 +308,6 @@ var VideoChat = {
         // Send ice candidate over websocket
         VideoChat.socket.emit("candidate", JSON.stringify(candidate), roomHash, uuid);
       });
-      // Reset the buffer of local ICE candidates. This is not really needed, but it's good practice
-      // VideoChat.localICECandidates[uuid] = [];
-    // } else {
-    //   console.log("attemped to run onAnswer on UUID ", uuid, " which already happened");
-    // }
-
-    
   },
 
   // Called when a stream is added to the peer connection

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -29,6 +29,8 @@ const chatZone = $("#chat-zone");
 
 var VideoChat = {
   nickname: undefined,
+  videoEnabled: true, 
+  audioEnabled: true, 
   connected: new Map(),
   localICECandidates: {},
   socket: io(),
@@ -480,21 +482,23 @@ function isConnected() {
 
 // Mute microphone
 function muteMicrophone() {
+  VideoChat.audioEnabled = !VideoChat.audioEnabled;
   var audioTrack = null;
-  // Get audio track to mute
-  VideoChat.peerConnections.first.getSenders().find(function (s) {
-    if (s.track.kind === "audio") {
-      audioTrack = s.track;
-    }
+
+  VideoChat.peerConnections.forEach(function(value, key, map) {
+    value.getSenders().find(function (s) {
+      if (s.track.kind === "audio") {
+        audioTrack = s.track;
+      }
+    })
+    audioTrack.enabled = VideoChat.audioEnabled;
   });
-  isMuted = !audioTrack.enabled;
-  audioTrack.enabled = isMuted;
-  isMuted = !isMuted;
+
   // select mic button and mic button text
   const micButtonIcon = document.getElementById("mic-icon");
   const micButtonText = document.getElementById("mic-text");
   // Update mute button text and icon
-  if (isMuted) {
+  if (!VideoChat.audioEnabled) {
     micButtonIcon.classList.remove("fa-microphone");
     micButtonIcon.classList.add("fa-microphone-slash");
     micButtonText.innerText = "Unmute";
@@ -508,21 +512,25 @@ function muteMicrophone() {
 
 // Pause Video
 function pauseVideo() {
-  var videoTrack = null;
-  // Get video track to pause
-  VideoChat.peerConnection.getSenders().find(function (s) {
-    if (s.track.kind === "video") {
-      videoTrack = s.track;
-    }
+  VideoChat.videoEnabled = !VideoChat.videoEnabled;
+
+  // Communicate pause to all the peers' video tracks
+  VideoChat.peerConnections.forEach(function(value, key, map) {
+    console.log("pausing video for ", key);
+    value.getSenders().find(function (s) {
+      if (s.track.kind === "video") {
+        console.log("found video track")
+        videoTrack = s.track;
+      }
+    })
+    videoTrack.enabled = VideoChat.videoEnabled;
   });
-  videoIsPaused = !videoTrack.enabled;
-  videoTrack.enabled = videoIsPaused;
-  videoIsPaused = !videoIsPaused;
+
   // select video button and video button text
   const videoButtonIcon = document.getElementById("video-icon");
   const videoButtonText = document.getElementById("video-text");
   // update pause button icon and text
-  if (videoIsPaused) {
+  if (!VideoChat.videoEnabled) {
     localVideoText.text("Video is paused");
     localVideoText.show();
     videoButtonIcon.classList.remove("fa-video");

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -914,21 +914,21 @@ function toggleChat() {
 function togglePictureInPicture() {
   if (
     "pictureInPictureEnabled" in document ||
-    remoteVideoVanilla.webkitSetPresentationMode
+    VideoChat.remoteVideoWrapper.lastChild.webkitSetPresentationMode
   ) {
     if (document.pictureInPictureElement) {
       document.exitPictureInPicture().catch((error) => {
         logIt("Error exiting pip.");
         logIt(error);
       });
-    } else if (remoteVideoVanilla.webkitPresentationMode === "inline") {
-      remoteVideoVanilla.webkitSetPresentationMode("picture-in-picture");
+    } else if (VideoChat.remoteVideoWrapper.lastChild.webkitPresentationMode === "inline") {
+      VideoChat.remoteVideoWrapper.lastChild.webkitSetPresentationMode("picture-in-picture");
     } else if (
-      remoteVideoVanilla.webkitPresentationMode === "picture-in-picture"
+      VideoChat.remoteVideoWrapper.lastChild.webkitPresentationMode === "picture-in-picture"
     ) {
-      remoteVideoVanilla.webkitSetPresentationMode("inline");
+      VideoChat.remoteVideoWrapper.lastChild.webkitSetPresentationMode("inline");
     } else {
-      remoteVideoVanilla.requestPictureInPicture().catch((error) => {
+      VideoChat.remoteVideoWrapper.lastChild.requestPictureInPicture().catch((error) => {
         alert(
           "You must be connected to another person to enter picture in picture."
         );

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -203,6 +203,12 @@ var VideoChat = {
             logIt("connected");
             break;
           case "disconnected":
+            // First possibility: we disconnected from the peer
+            if (VideoChat.socket.connect().connected === false) {
+              location.reload();
+            }
+
+            // Second possibility: the peer disconnected from us
             logIt("disconnected - UUID " + uuid);
             VideoChat.remoteVideoWrapper.removeChild(
               document.querySelectorAll(`[uuid="${uuid}"]`)[0]

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -32,7 +32,6 @@ var dataChannel = new Map();
 var VideoChat = {
   videoEnabled: true,
   audioEnabled: true,
-  borderColor: `hsl(${Math.floor(Math.random() * 360)}, 70%, 80%)`,
   connected: new Map(),
   localICECandidates: {},
   socket: io(),
@@ -40,7 +39,7 @@ var VideoChat = {
   localVideo: document.getElementById("local-video"),
   peerConnections: new Map(),
   recognition: undefined,
-  borderColor: undefined,
+  borderColor: "hsl(120,100%,70%)",
   peerColors: new Map(),
 
   // Call to getUserMedia (provided by adapter.js for cross browser compatibility)
@@ -99,7 +98,7 @@ var VideoChat = {
       },
     });
 
-    VideoChat.borderColor = uuidToColor(VideoChat.socket.id);
+    // VideoChat.borderColor = uuidToColor(VideoChat.socket.id);
     VideoChat.localVideo.srcObject = stream;
     VideoChat.localVideo.style.border = `3px solid ${VideoChat.borderColor}`;
 
@@ -666,7 +665,7 @@ function switchStreamHelper(stream) {
     }
   });
   // Update local video stream
-  VideoChat.localStream = videoTrack;
+  VideoChat.localStream = stream;
   // Update local video object
   VideoChat.localVideo.srcObject = stream;
   // Unpause video on swap

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -94,12 +94,9 @@ var VideoChat = {
     VideoChat.localVideo.srcObject = stream;
     // Now we're ready to join the chat room.
     VideoChat.socket.emit("join", roomHash);
-    // Receive its own uuid
-    VideoChat.socket.on("uuid", (uuid) => (VideoChat.uuid = uuid));
     // Add listeners to the websocket
     VideoChat.socket.on("full", chatRoomFull);
     VideoChat.socket.on("offer", VideoChat.onOffer);
-    VideoChat.socket.on("ready", VideoChat.readyToCall);
     VideoChat.socket.on("willInitiateCall", VideoChat.call);
     // Set up listeners on the socket
     VideoChat.socket.on("candidate", VideoChat.onCandidate);
@@ -110,17 +107,9 @@ var VideoChat = {
     );
   },
 
-  // When we are ready to call, enable the Call button.
-  readyToCall: function (event) {
-    logIt("readyToCall");
-  },
-  call: function (uuid, room) {
-    logIt("Initiating call");
-    VideoChat.startCall(uuid);
-  },
 
-  // Set up a callback to run when we have the ephemeral token to use Twilio's TURN server.
-  startCall: function (uuid) {
+  call: function (uuid, room) {
+    logIt("Initiating call with " + uuid);
     VideoChat.socket.on(
       "token",
       VideoChat.establishConnection(uuid, function (a) {
@@ -136,8 +125,8 @@ var VideoChat = {
         return;
       }
       console.log("establishing connection to", uuid);
-
-      VideoChat.localICECandidates[uuid] = []; // initialise uuid with empty array
+      // Initialise localICEcandidates for node uuid with empty array
+      VideoChat.localICECandidates[uuid] = [];
       VideoChat.connected[uuid] = false;
 
       // Set up a new RTCPeerConnection using the token's iceServers.
@@ -191,8 +180,6 @@ var VideoChat = {
           case "connected":
             logIt("connected");
             // Once connected we no longer have a need for the signaling server, so disconnect
-            // VideoChat.socket.off("token");
-            // VideoChat.socket.off("offer");
             break;
           case "disconnected":
             logIt("disconnected");
@@ -251,12 +238,7 @@ var VideoChat = {
 
   // Create an offer that contains the media capabilities of the browser.
   createOffer: function (uuid) {
-    console.log(
-      ">>> Creating offer to UUID: ",
-      uuid,
-      ". my UUID is",
-      VideoChat.socket.id
-    );
+    logIt(`createOffer to ${uuid} >>> Creating offer...`);
     VideoChat.peerConnections[uuid].createOffer(
       function (offer) {
         // If the offer is created successfully, set it as the local description
@@ -280,22 +262,11 @@ var VideoChat = {
   createAnswer: function (offer, uuid) {
     logIt("createAnswer");
     rtcOffer = new RTCSessionDescription(JSON.parse(offer));
-    console.log(
-      "createAnswer: setting remote description of " +
-        uuid +
-        " on " +
-        VideoChat.socket.id
-    );
+    logIt(`>>> Creating answer to ${uuid}`);
     VideoChat.peerConnections[uuid].setRemoteDescription(rtcOffer);
     VideoChat.peerConnections[uuid].createAnswer(
       function (answer) {
         VideoChat.peerConnections[uuid].setLocalDescription(answer);
-        console.log(
-          ">>> Creating answer to UUID: ",
-          uuid,
-          ". my UUID is",
-          VideoChat.socket.id
-        );
         VideoChat.socket.emit("answer", JSON.stringify(answer), roomHash, uuid);
       },
       function (err) {
@@ -321,22 +292,9 @@ var VideoChat = {
 
   // When an answer is received, add it to the peerConnection as the remote description.
   onAnswer: function (answer, uuid) {
-    console.log(
-      "onAnswer <<< Received answer",
-      uuid,
-      ". my UUID is",
-      VideoChat.socket.id
-    );
-
-    // logIt("onAnswer <<< Received answer" + "");
+    logIt(`onAnswer <<< Received answer from ${uuid}`);
     var rtcAnswer = new RTCSessionDescription(JSON.parse(answer));
     // Set remote description of RTCSession
-    console.log(
-      "onAnswer: setting remote description of " +
-        uuid +
-        " on " +
-        VideoChat.socket.id
-    );
     VideoChat.peerConnections[uuid].setRemoteDescription(rtcAnswer);
     // The caller now knows that the callee is ready to accept new ICE candidates, so sending the buffer over
     VideoChat.localICECandidates[uuid].forEach((candidate) => {
@@ -353,14 +311,8 @@ var VideoChat = {
 
   // Called when a stream is added to the peer connection
   onAddStream: function (event, uuid) {
-    // if(VideoChat.counter > 4) {
-    //     VideoChat.socket.disconnect();
-    // }else{
-    //   VideoChat.counter++;
-    // }
     logIt(
-      "onAddStream <<< Received new stream from remote. Adding it..." + event
-    );
+      "onAddStream <<< Received new stream from remote. Adding it...");
     // Create new remote video source in wrapper
     // Create a <video> node
     var node = document.createElement("video");

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -73,6 +73,7 @@ var VideoChat = {
   onMediaStream: function (stream) {
     logIt("onMediaStream");
     VideoChat.localStream = stream;
+    VideoChat.localAudio = stream.getAudioTracks()[0];
     // Add the stream as video's srcObject.
     // Now that we have webcam video sorted, prompt user to share URL
     Snackbar.show({
@@ -610,6 +611,8 @@ function swap() {
         swapIcon.classList.remove("fa-desktop");
         swapIcon.classList.add("fa-camera");
         swapText.innerText = "Share Webcam";
+        stream.addTrack(VideoChat.localAudio);
+        console.log(stream);
         switchStreamHelper(stream);
       })
       .catch(function (err) {
@@ -620,7 +623,7 @@ function swap() {
     // If mode is screenshare then switch to webcam
   } else {
     // Stop the screen share track
-    VideoChat.localVideo.srcObject.getTracks().forEach((track) => track.stop());
+    VideoChat.localVideo.srcObject.getVideoTracks().forEach((track) => track.stop());
     // Get webcam input
     navigator.mediaDevices
       .getUserMedia({

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -501,6 +501,8 @@ function sendToAllDataChannels(message) {
 function muteMicrophone() {
   var audioTrack = null;
 
+  VideoChat.audioEnabled = !VideoChat.audioEnabled;
+
   VideoChat.peerConnections.forEach(function (value, key, map) {
     value.getSenders().find(function (s) {
       if (s.track.kind === "audio") {
@@ -509,8 +511,6 @@ function muteMicrophone() {
     });
     audioTrack.enabled = VideoChat.audioEnabled;
   });
-
-  VideoChat.audioEnabled = !VideoChat.audioEnabled;
 
   // select mic button and mic button text
   const micButtonIcon = document.getElementById("mic-icon");
@@ -865,7 +865,7 @@ function handleRecieveMessage(msg) {
 
 // Sets the border color of uuid's stream upon receiving color
 function setStreamColor(uuid, color) {
-  document.querySelectorAll(`[uuid="${uuid}"]`)[0].style.border = `4px solid ${color}`;
+  document.querySelectorAll(`[uuid="${uuid}"]`)[0].style.border = `3px solid ${color}`;
 }
 
 // Show and hide chat

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -364,11 +364,11 @@ var VideoChat = {
     // Hide caption status text
     captionText.fadeOut();
     // Downscale send resolution and bitrate if num in room > 4
-    if (VideoChat.peerConnections.size > 3) {
-      VideoChat.peerConnections.forEach(function (value, key, map) {
-        downscaleStream(value);
-      });
-    }
+    // if (VideoChat.peerConnections.size > 3) {
+    //   VideoChat.peerConnections.forEach(function (value, key, map) {
+    //     downscaleStream(value);
+    //   });
+    // }
     // Reposition local video after a second, as there is often a delay
     // between adding a stream and the height of the video div changing
     setTimeout(() => rePositionLocalVideo(), 500);
@@ -508,30 +508,30 @@ function sendToAllDataChannels(message) {
 // End Fullscreen
 
 // Downscale single stream
-async function downscaleStream(pc, applying = false) {
-  height = 240;
-  rate = 800000;
-  if (applying) return;
-  try {
-    applying = true;
-    do {
-      h = height;
-      const sender = pc.getSenders().find(function (s) {
-        return s.track.kind === "video";
-      });
-      const ratio = sender.track.getSettings().height / height;
-      const params = sender.getParameters();
-      if (!params.encodings) params.encodings = [{}]; // Firefox workaround!
-      params.encodings[0].scaleResolutionDownBy = Math.max(ratio, 1);
-      params.encodings[0].maxBitrate = rate;
-      await sender.setParameters(params);
-    } while (h != height);
-  } catch (e) {
-    logIt(e);
-  } finally {
-    applying = false;
-  }
-}
+// async function downscaleStream(pc, applying = false) {
+//   height = 240;
+//   rate = 800000;
+//   if (applying) return;
+//   try {
+//     applying = true;
+//     do {
+//       h = height;
+//       const sender = pc.getSenders().find(function (s) {
+//         return s.track.kind === "video";
+//       });
+//       const ratio = sender.track.getSettings().height / height;
+//       const params = sender.getParameters();
+//       if (!params.encodings) params.encodings = [{}]; // Firefox workaround!
+//       params.encodings[0].scaleResolutionDownBy = Math.max(ratio, 1);
+//       params.encodings[0].maxBitrate = rate;
+//       await sender.setParameters(params);
+//     } while (h != height);
+//   } catch (e) {
+//     logIt(e);
+//   } finally {
+//     applying = false;
+//   }
+// }
 
 // Mute microphone
 function muteMicrophone() {

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -37,10 +37,10 @@ var VideoChat = {
   socket: io(),
   remoteVideoWrapper: document.getElementById("wrapper"),
   localVideo: document.getElementById("local-video"),
+  peerColors: new Map(),
   peerConnections: new Map(),
   recognition: undefined,
   borderColor: undefined,
-  peerColors: new Map(),
 
   // Call to getUserMedia (provided by adapter.js for cross browser compatibility)
   // asking for access to both the video and audio streams. If the request is
@@ -98,17 +98,17 @@ var VideoChat = {
       },
     });
 
-    VideoChat.borderColor = uuidToColor(VideoChat.socket.id);
     VideoChat.localVideo.srcObject = stream;
-    VideoChat.localVideo.style.border = `3px solid ${VideoChat.borderColor}`;
 
     // Now we're ready to join the chat room.
     VideoChat.socket.emit("join", roomHash);
+    VideoChat.borderColor = uuidToColor(VideoChat.socket.id);
+    VideoChat.localVideo.style.border = `3px solid ${VideoChat.borderColor}`;
 
     // Add listeners to the websocket
     VideoChat.socket.on("full", chatRoomFull);
     VideoChat.socket.on("offer", VideoChat.onOffer);
-    VideoChat.socket.on("willInitiateCall", VideoChat.call);
+    VideoChat.socket.on("initiateCall", VideoChat.call);
 
     // Set up listeners on the socket
     VideoChat.socket.on("candidate", VideoChat.onCandidate);

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -40,7 +40,7 @@ var VideoChat = {
   peerConnections: new Map(),
   recognition: undefined,
   borderColor: undefined,
-  peerColors: {},
+  peerColors: new Map(),
 
   // Call to getUserMedia (provided by adapter.js for cross browser compatibility)
   // asking for access to both the video and audio streams. If the request is
@@ -861,15 +861,28 @@ function uuidToColor(uuid) {
   var hash = 0;
   for (var i = 0; i < uuid.length; i++) {
       hash = uuid.charCodeAt(i) + ((hash << 5) - hash);
-      hash &= hash; // Convert to 32bit integer
+      hash = hash & hash;
   }
-  return `hsl(${hash % 360},100%,40%)`;
+  var hue = Math.abs(hash % 360);
+  console.log(hue);
+  // Ensure color is not similar to other colors
+  var availColors = Array.from({length: 18}, (x,i) => i*20);
+  VideoChat.peerColors.forEach(function(value, key, map) {availColors[Math.floor(value/20)] = null});
+  if (availColors[Math.floor(hue/20)] == null) {
+    for (var i = 0; i < availColors.length; i++) {
+      if (availColors[i] != null) {
+        hue = (hue % 20) + availColors[i];
+        availColors[i] = null;
+        break;
+      }
+    }
+  }
+  return `hsl(${hue},100%,70%)`;
 }
 
 // Sets the border color of uuid's stream
 function setStreamColor(uuid) {
   const color = uuidToColor(uuid);
-  console.log(color);
   document.querySelectorAll(`[uuid="${uuid}"]`)[0].style.border = `3px solid ${color}`;
   VideoChat.peerColors[uuid] = color;
 }

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -199,7 +199,16 @@ var VideoChat = {
             // VideoChat.socket.off("offer");
             break;
           case "disconnected":
-            logIt("disconnected");
+            logIt("disconnected - UUID " + uuid);
+            VideoChat.remoteVideoWrapper.removeChild(document.querySelectorAll(`[uuid="${uuid}"]`)[0]);
+            VideoChat.connected.delete(uuid);
+            VideoChat.peerConnections.delete(uuid);
+            dataChannel.delete(uuid);
+
+            if (VideoChat.peerConnections.size === 0) {
+              displayWaitingCaption();
+            }
+            break;
           case "failed":
             logIt("failed");
             // VideoChat.socket.connect
@@ -332,6 +341,7 @@ var VideoChat = {
     node.setAttribute("autoplay", "");
     node.setAttribute("playsinline", "");
     node.setAttribute("id", "remote-video");
+    node.setAttribute("uuid", uuid);
     VideoChat.remoteVideoWrapper.appendChild(node);
     // Update remote video source
     VideoChat.remoteVideoWrapper.lastChild.srcObject = event.stream;
@@ -870,7 +880,7 @@ function toggleChat() {
 }
 // End Text chat
 
-//Picture in picture
+// Picture in picture
 function togglePictureInPicture() {
   if (
     "pictureInPictureEnabled" in document ||
@@ -900,7 +910,15 @@ function togglePictureInPicture() {
     );
   }
 }
-//Picture in picture
+
+// Helper function for displaying waiting caption
+function displayWaitingCaption() {
+  // Set caption text on start
+  captionText.text("Waiting for other user to join...").fadeIn();
+
+  // Reposition captions on start
+  rePositionCaptions();
+}
 
 function startUp() {
   //  Try and detect in-app browsers and redirect
@@ -994,11 +1012,7 @@ function startUp() {
     },
   });
 
-  // Set caption text on start
-  captionText.text("Waiting for other user to join...").fadeIn();
-
-  // Reposition captions on start
-  rePositionCaptions();
+  displayWaitingCaption();
 
   // On change media devices refresh page and switch to system default
   navigator.mediaDevices.ondevicechange = () => window.location.reload();

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -30,7 +30,6 @@ const chatZone = $("#chat-zone");
 var dataChannel = new Map();
 
 var VideoChat = {
-  nickname: undefined,
   videoEnabled: true,
   audioEnabled: true,
   connected: new Map(),
@@ -96,16 +95,6 @@ var VideoChat = {
         Snackbar.close();
       },
     });
-
-    // Used to identify client to other peers in chats, captions etc.
-    VideoChat.nickname = prompt("Please enter a nickname", "");
-
-    while (VideoChat.nickname == null || VideoChat.nickname.trim() === "") {
-      VideoChat.nickname = prompt(
-        "Nickname cannot be empty. Please enter a nickname",
-        ""
-      );
-    }
 
     VideoChat.localVideo.srcObject = stream;
 
@@ -806,7 +795,6 @@ function recieveCaptions(captions) {
 // Text Chat
 // Add text message to chat screen on page
 function addMessageToScreen(msg, isOwnMessage) {
-  // If nickname is undefined or null, user didn't input a nickname
   if (isOwnMessage) {
     $(".chat-messages").append(
       '<div class="message-item customer cssanimation fadeInBottom"><div class="message-bloc"><div class="message">' +
@@ -833,7 +821,7 @@ chatInput.addEventListener("keypress", function (event) {
     // Make links clickable
     msg = msg.autoLink();
     // Send message over data channel
-    sendToAllDataChannels("mes:" + VideoChat.nickname + ": " + msg);
+    sendToAllDataChannels("mes:" + msg);
     // Add message to screen
     addMessageToScreen(msg, true);
     // Auto scroll chat down

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -32,7 +32,6 @@ var dataChannel = new Map();
 var VideoChat = {
   videoEnabled: true,
   audioEnabled: true,
-  borderColor: `hsl(${Math.floor(Math.random() * 360)}, 70%, 80%)`,
   connected: new Map(),
   localICECandidates: {},
   socket: io(),
@@ -364,11 +363,11 @@ var VideoChat = {
     // Hide caption status text
     captionText.fadeOut();
     // Downscale send resolution and bitrate if num in room > 4
-    if (VideoChat.peerConnections.size > 3) {
-      VideoChat.peerConnections.forEach(function (value, key, map) {
-        downscaleStream(value);
-      });
-    }
+    // if (VideoChat.peerConnections.size > 3) {
+    //   VideoChat.peerConnections.forEach(function (value, key, map) {
+    //     downscaleStream(value);
+    //   });
+    // }
     // Reposition local video after a second, as there is often a delay
     // between adding a stream and the height of the video div changing
     setTimeout(() => rePositionLocalVideo(), 500);
@@ -508,30 +507,30 @@ function sendToAllDataChannels(message) {
 // End Fullscreen
 
 // Downscale single stream
-async function downscaleStream(pc, applying = false) {
-  height = 240;
-  rate = 800000;
-  if (applying) return;
-  try {
-    applying = true;
-    do {
-      h = height;
-      const sender = pc.getSenders().find(function (s) {
-        return s.track.kind === "video";
-      });
-      const ratio = sender.track.getSettings().height / height;
-      const params = sender.getParameters();
-      if (!params.encodings) params.encodings = [{}]; // Firefox workaround!
-      params.encodings[0].scaleResolutionDownBy = Math.max(ratio, 1);
-      params.encodings[0].maxBitrate = rate;
-      await sender.setParameters(params);
-    } while (h != height);
-  } catch (e) {
-    logIt(e);
-  } finally {
-    applying = false;
-  }
-}
+// async function downscaleStream(pc, applying = false) {
+//   height = 240;
+//   rate = 800000;
+//   if (applying) return;
+//   try {
+//     applying = true;
+//     do {
+//       h = height;
+//       const sender = pc.getSenders().find(function (s) {
+//         return s.track.kind === "video";
+//       });
+//       const ratio = sender.track.getSettings().height / height;
+//       const params = sender.getParameters();
+//       if (!params.encodings) params.encodings = [{}]; // Firefox workaround!
+//       params.encodings[0].scaleResolutionDownBy = Math.max(ratio, 1);
+//       params.encodings[0].maxBitrate = rate;
+//       await sender.setParameters(params);
+//     } while (h != height);
+//   } catch (e) {
+//     logIt(e);
+//   } finally {
+//     applying = false;
+//   }
+// }
 
 // Mute microphone
 function muteMicrophone() {
@@ -902,20 +901,20 @@ function uuidToColor(uuid) {
   }
   var hue = Math.abs(hash % 360);
   // Ensure color is not similar to other colors
-  var availColors = Array.from({ length: 18 }, (x, i) => i * 20);
+  var availColors = Array.from({ length: 9 }, (x, i) => i * 40);
   VideoChat.peerColors.forEach(function (value, key, map) {
-    availColors[Math.floor(value / 20)] = null;
+    availColors[Math.floor(value / 40)] = null;
   });
-  if (availColors[Math.floor(hue / 20)] == null) {
+  if (availColors[Math.floor(hue / 40)] == null) {
     for (var i = 0; i < availColors.length; i++) {
       if (availColors[i] != null) {
-        hue = (hue % 20) + availColors[i];
+        hue = (hue % 40) + availColors[i];
         availColors[i] = null;
         break;
       }
     }
   }
-  return `hsl(${hue},100%,70%)`;
+  return `hsl(${hue},100%,60%)`;
 }
 
 // Sets the border color of uuid's stream

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -216,7 +216,8 @@ var VideoChat = {
         VideoChat.socket.emit(
           "candidate",
           JSON.stringify(event.candidate),
-          roomHash
+          roomHash,
+          uuid
         );
       } else {
         // If we are not 'connected' to the other peer, we are buffering the local ICE candidates.

--- a/public/landing.html
+++ b/public/landing.html
@@ -67,9 +67,9 @@
                       class="mt-0 mb-32 reveal-from-bottom"
                       data-reveal-delay="300"
                     >
-                      Simple, Secure, and Fast. Peer to peer video calling
-                      provides quality and latency simply not available with
-                      traditional technology.
+                      Simple, Secure, and Fast. Peer to peer group video
+                      calling provides quality and latency simply not
+                      available with traditional technology.
                     </p>
                     <div class="reveal-from-bottom" data-reveal-delay="450">
                       <a
@@ -191,18 +191,19 @@
                     <div class="features-tiles-item-header">
                       <div class="features-tiles-item-image mb-16">
                         <img
-                          src="images/feature-tile-icon-03.svg"
-                          alt="Feature tile icon 03"
+                          src="images/feature-tile-icon-06.svg"
+                          alt="Feature tile icon 06"
                           width="72"
                           height="72"
                         />
                       </div>
                     </div>
                     <div class="features-tiles-item-content">
-                      <h4 class="mt-0 mb-8">Total Privacy</h4>
+                      <h4 class="mt-0 mb-8">Decentralized group calls</h4>
                       <p class="m-0 text-sm">
-                        Each chat is single use, data stays between you and your
-                        caller. Zipcall is built privacy first.
+                        Zipcall lets you talk to up to four friends by
+                        directly connecting to them, completely
+                        decentralized.
                       </p>
                     </div>
                   </div>
@@ -236,17 +237,18 @@
                     <div class="features-tiles-item-header">
                       <div class="features-tiles-item-image mb-16">
                         <img
-                          src="images/feature-tile-icon-06.svg"
-                          alt="Feature tile icon 06"
+                          src="images/feature-tile-icon-03.svg"
+                          alt="Feature tile icon 03"
                           width="72"
                           height="72"
                         />
                       </div>
                     </div>
                     <div class="features-tiles-item-content">
-                      <h4 class="mt-0 mb-8">Maximum Security</h4>
+                      <h4 class="mt-0 mb-8">Total Privacy and Security</h4>
                       <p class="m-0 text-sm">
-                        End to end state of the art encryption means your calls
+                        Zipcall is built privacy first. Each chat is single use,
+                        and end to end state of the art encryption means your calls
                         are exactly that. Your calls.
                       </p>
                     </div>

--- a/public/landing.html
+++ b/public/landing.html
@@ -67,9 +67,9 @@
                       class="mt-0 mb-32 reveal-from-bottom"
                       data-reveal-delay="300"
                     >
-                      Simple, Secure, and Fast. Peer to peer group video
-                      calling provides quality and latency simply not
-                      available with traditional technology.
+                      Simple, Secure, and Fast. Peer to peer group video calling
+                      provides quality and latency simply not available with
+                      traditional technology.
                     </p>
                     <div class="reveal-from-bottom" data-reveal-delay="450">
                       <a
@@ -201,9 +201,8 @@
                     <div class="features-tiles-item-content">
                       <h4 class="mt-0 mb-8">Decentralized group calls</h4>
                       <p class="m-0 text-sm">
-                        Zipcall lets you talk to up to four friends by
-                        directly connecting to them, completely
-                        decentralized.
+                        Zipcall lets you talk to up to four friends by directly
+                        connecting to them, completely decentralized.
                       </p>
                     </div>
                   </div>
@@ -248,8 +247,8 @@
                       <h4 class="mt-0 mb-8">Total Privacy and Security</h4>
                       <p class="m-0 text-sm">
                         Zipcall is built privacy first. Each chat is single use,
-                        and end to end state of the art encryption means your calls
-                        are exactly that. Your calls.
+                        and end to end state of the art encryption means your
+                        calls are exactly that. Your calls.
                       </p>
                     </div>
                   </div>

--- a/server.js
+++ b/server.js
@@ -9,11 +9,11 @@ var twilio = require("twilio")(twillioAccountSID, twillioAuthToken);
 var express = require("express");
 var app = express();
 const fs = require('fs');
-var http = require("https").createServer({
-  key: fs.readFileSync('/Users/khushjammu/certs/privkey.pem'),
-  cert: fs.readFileSync('/Users/khushjammu/certs/cert.pem')
-}, app);
-// var http = require("http").createServer(app);
+// var http = require("https").createServer({
+//   key: fs.readFileSync('/Users/khushjammu/certs/privkey.pem'),
+//   cert: fs.readFileSync('/Users/khushjammu/certs/cert.pem')
+// }, app);
+var http = require("http").createServer(app);
 var io = require("socket.io")(http);
 var path = require("path");
 var public = path.join(__dirname, "public");

--- a/server.js
+++ b/server.js
@@ -9,11 +9,7 @@ var twilio = require("twilio")(twillioAccountSID, twillioAuthToken);
 var express = require("express");
 var app = express();
 const fs = require('fs');
-var http = require("https").createServer({
-  key: fs.readFileSync('/Users/khushjammu/certs/privkey.pem'),
-  cert: fs.readFileSync('/Users/khushjammu/certs/cert.pem')
-}, app);
-// var http = require("http").createServer(app);
+var http = require("http").createServer(app);
 var io = require("socket.io")(http);
 var path = require("path");
 var public = path.join(__dirname, "public");
@@ -145,7 +141,7 @@ io.on("connection", function (socket) {
 });
 
 // Listen for Heroku port, otherwise just use 3000
-var port = process.env.PORT || 443;
+var port = process.env.PORT || 3000;
 http.listen(port, function () {
   console.log("http://localhost:" + port);
 });

--- a/server.js
+++ b/server.js
@@ -8,11 +8,14 @@ var twillioAccountSID =
 var twilio = require("twilio")(twillioAccountSID, twillioAuthToken);
 var express = require("express");
 var app = express();
-const fs = require('fs');
-var http = require("https").createServer({
-  key: fs.readFileSync('/Users/khushjammu/certs/privkey.pem'),
-  cert: fs.readFileSync('/Users/khushjammu/certs/cert.pem')
-}, app);
+const fs = require("fs");
+var http = require("https").createServer(
+  {
+    key: fs.readFileSync("/Users/khushjammu/certs/privkey.pem"),
+    cert: fs.readFileSync("/Users/khushjammu/certs/cert.pem"),
+  },
+  app
+);
 // var http = require("http").createServer(app);
 var io = require("socket.io")(http);
 var path = require("path");
@@ -94,9 +97,9 @@ io.on("connection", function (socket) {
       });
     } else if (numClients < 4) {
       socket.join(room);
-      logIt("Connected clients", room)
+      logIt("Connected clients", room);
       for (var clientId in clients.sockets) {
-        logIt('ID: ' + clientId, room);
+        logIt("ID: " + clientId, room);
       }
 
       // When the client is not the first to join the room, all clients are ready.
@@ -106,7 +109,10 @@ io.on("connection", function (socket) {
       socket.emit("ready", room).to(room);
       socket.broadcast.to(room).emit("ready", room);
     } else {
-      logIt("room already full with " + numClients + " people in the room.", room);
+      logIt(
+        "room already full with " + numClients + " people in the room.",
+        room
+      );
       socket.emit("full", room);
     }
   });
@@ -133,13 +139,19 @@ io.on("connection", function (socket) {
 
   // Relay offers
   socket.on("offer", function (offer, room, uuid) {
-    logIt("Received offer from " + socket.id + " and emitting to " + uuid, room);
+    logIt(
+      "Received offer from " + socket.id + " and emitting to " + uuid,
+      room
+    );
     io.to(uuid).emit("offer", offer, socket.id);
   });
 
   // Relay answers
   socket.on("answer", function (answer, room, uuid) {
-    logIt("Received answer from " + socket.id + " and emitting to " + uuid, room);
+    logIt(
+      "Received answer from " + socket.id + " and emitting to " + uuid,
+      room
+    );
     io.to(uuid).emit("answer", answer, socket.id);
   });
 });

--- a/server.js
+++ b/server.js
@@ -72,8 +72,10 @@ function logIt(msg, room) {
 io.on("connection", function (socket) {
   // When a client tries to join a room, only allow them if they are first or
   // second in the room. Otherwise it is full.
-  socket.on("join", function (room) {
+  socket.on("join", function (room, acknowledgement) {
     logIt("A client joined the room", room);
+    acknowledgement();
+
     var clients = io.sockets.adapter.rooms[room];
     var numClients = typeof clients !== "undefined" ? clients.length : 0;
     if (numClients === 0) {

--- a/server.js
+++ b/server.js
@@ -8,7 +8,11 @@ var twillioAccountSID =
 var twilio = require("twilio")(twillioAccountSID, twillioAuthToken);
 var express = require("express");
 var app = express();
-var http = require("http").createServer(app);
+const fs = require('fs');
+var http = require("https").createServer({
+  key: fs.readFileSync('/Users/khushjammu/certs/privkey.pem'),
+  cert: fs.readFileSync('/Users/khushjammu/certs/cert.pem')
+}, app);
 var io = require("socket.io")(http);
 var path = require("path");
 var public = path.join(__dirname, "public");
@@ -132,7 +136,7 @@ io.on("connection", function (socket) {
 });
 
 // Listen for Heroku port, otherwise just use 3000
-var port = process.env.PORT || 3000;
+var port = process.env.PORT || 443;
 http.listen(port, function () {
   console.log("http://localhost:" + port);
 });

--- a/server.js
+++ b/server.js
@@ -9,10 +9,11 @@ var twilio = require("twilio")(twillioAccountSID, twillioAuthToken);
 var express = require("express");
 var app = express();
 const fs = require('fs');
-var http = require("https").createServer({
-  key: fs.readFileSync('/Users/khushjammu/certs/privkey.pem'),
-  cert: fs.readFileSync('/Users/khushjammu/certs/cert.pem')
-}, app);
+// var http = require("https").createServer({
+//   key: fs.readFileSync('/Users/khushjammu/certs/privkey.pem'),
+//   cert: fs.readFileSync('/Users/khushjammu/certs/cert.pem')
+// }, app);
+var http = require("http").createServer(app);
 var io = require("socket.io")(http);
 var path = require("path");
 var public = path.join(__dirname, "public");
@@ -144,7 +145,7 @@ io.on("connection", function (socket) {
 });
 
 // Listen for Heroku port, otherwise just use 3000
-var port = process.env.PORT || 443;
+var port = process.env.PORT || 3000;
 http.listen(port, function () {
   console.log("http://localhost:" + port);
 });

--- a/server.js
+++ b/server.js
@@ -8,7 +8,11 @@ var twillioAccountSID =
 var twilio = require("twilio")(twillioAccountSID, twillioAuthToken);
 var express = require("express");
 var app = express();
-var http = require("http").createServer(app);
+const fs = require('fs');
+var http = require("https").createServer({
+  key: fs.readFileSync('/Users/khushjammu/certs/privkey.pem'),
+  cert: fs.readFileSync('/Users/khushjammu/certs/cert.pem')
+}, app);
 var io = require("socket.io")(http);
 var path = require("path");
 var public = path.join(__dirname, "public");
@@ -140,7 +144,7 @@ io.on("connection", function (socket) {
 });
 
 // Listen for Heroku port, otherwise just use 3000
-var port = process.env.PORT || 3000;
+var port = process.env.PORT || 443;
 http.listen(port, function () {
   console.log("http://localhost:" + port);
 });

--- a/server.js
+++ b/server.js
@@ -8,11 +8,7 @@ var twillioAccountSID =
 var twilio = require("twilio")(twillioAccountSID, twillioAuthToken);
 var express = require("express");
 var app = express();
-const fs = require('fs');
-var http = require("https").createServer({
-  key: fs.readFileSync('/Users/khushjammu/certs/privkey.pem'),
-  cert: fs.readFileSync('/Users/khushjammu/certs/cert.pem')
-}, app);
+var http = require("http").createServer(app);
 var io = require("socket.io")(http);
 var path = require("path");
 var public = path.join(__dirname, "public");
@@ -136,7 +132,7 @@ io.on("connection", function (socket) {
 });
 
 // Listen for Heroku port, otherwise just use 3000
-var port = process.env.PORT || 443;
+var port = process.env.PORT || 3000;
 http.listen(port, function () {
   console.log("http://localhost:" + port);
 });

--- a/server.js
+++ b/server.js
@@ -78,6 +78,15 @@ io.on("connection", function (socket) {
     var numClients = typeof clients !== "undefined" ? clients.length : 0;
     if (numClients === 0) {
       socket.join(room);
+      twilio.tokens.create(function (err, response) {
+        if (err) {
+          logIt(err, room);
+        } else {
+          logIt("Token generated. Returning it to the browser client", room);
+          socket.emit("token", response);
+          // Existing callers initiates call with user
+        }
+      });
     } else if (numClients < 3) {
       socket.join(room);
       logIt("Connected clients", room)
@@ -87,10 +96,17 @@ io.on("connection", function (socket) {
 
       // When the client is not the first to join the room, all clients are ready.
       logIt("Broadcasting ready message", room);
-      // Existing callers initiates call with user
-      socket.broadcast.to(room).emit("willInitiateCall", socket.id, room);
 
-      // Send its uui
+      twilio.tokens.create(function (err, response) {
+        if (err) {
+          logIt(err, room);
+        } else {
+          logIt("Token generated. Returning it to the browser client", room);
+          socket.emit("token", response);
+          // Existing callers initiates call with user
+          socket.broadcast.to(room).emit("willInitiateCall", socket.id, room);
+        }
+      });
       // socket.emit("uuid", socket.id);
       socket.emit("ready", room).to(room);
       socket.broadcast.to(room).emit("ready", room);
@@ -109,7 +125,7 @@ io.on("connection", function (socket) {
         logIt(err, room);
       } else {
         logIt("Token generated. Returning it to the browser client", room);
-        socket.emit("token", response).to(room);
+        socket.emit("token", response);
       }
     });
   });

--- a/server.js
+++ b/server.js
@@ -93,6 +93,11 @@ io.on("connection", function (socket) {
     }
   });
 
+  socket.on("leave", function (room) {
+    logIt("A client has left the room", room);
+    socket.broadcast.to(room).emit("leave", socket.id);
+  });
+
   // When receiving the token message, use the Twilio REST API to request an
   // token to get ephemeral credentials to use the TURN server.
   socket.on("token", function (room, uuid) {

--- a/server.js
+++ b/server.js
@@ -92,7 +92,7 @@ io.on("connection", function (socket) {
           // Existing callers initiates call with user
         }
       });
-    } else if (numClients < 4) {
+    } else if (numClients < 5) {
       socket.join(room);
       logIt("Connected clients", room);
       for (var clientId in clients.sockets) {
@@ -102,9 +102,6 @@ io.on("connection", function (socket) {
       // When the client is not the first to join the room, all clients are ready.
       logIt("Broadcasting ready message", room);
       socket.broadcast.to(room).emit("willInitiateCall", socket.id, room);
-      // socket.emit("uuid", socket.id);
-      socket.emit("ready", room).to(room);
-      socket.broadcast.to(room).emit("ready", room);
     } else {
       logIt(
         "room already full with " + numClients + " people in the room.",

--- a/server.js
+++ b/server.js
@@ -145,7 +145,7 @@ io.on("connection", function (socket) {
 });
 
 // Listen for Heroku port, otherwise just use 3000
-var port = process.env.PORT || 443;
+var port = process.env.PORT || 3000;
 http.listen(port, function () {
   console.log("http://localhost:" + port);
 });

--- a/server.js
+++ b/server.js
@@ -92,6 +92,11 @@ io.on("connection", function (socket) {
     }
   });
 
+  socket.on("leave", function (room) {
+    logIt("A client has left the room", room);
+    socket.broadcast.to(room).emit("leave", socket.id);
+  });
+
   // When receiving the token message, use the Twilio REST API to request an
   // token to get ephemeral credentials to use the TURN server.
   socket.on("token", function (room, uuid) {

--- a/server.js
+++ b/server.js
@@ -8,7 +8,6 @@ var twillioAccountSID =
 var twilio = require("twilio")(twillioAccountSID, twillioAuthToken);
 var express = require("express");
 var app = express();
-const fs = require('fs');
 var http = require("http").createServer(app);
 var io = require("socket.io")(http);
 var path = require("path");
@@ -81,9 +80,9 @@ io.on("connection", function (socket) {
       socket.join(room);
     } else if (numClients < 5) {
       socket.join(room);
-      logIt("Broadcasting request to connect with new peer...", room);
-      // Emits message to ask peers in room to connect with joining peer
-      socket.broadcast.to(room).emit("initiateCall", socket.id, room);
+      // When the client is not the first to join the room, all clients are ready.
+      logIt("Broadcasting ready message", room);
+      socket.broadcast.to(room).emit("willInitiateCall", socket.id, room);
     } else {
       logIt(
         "room already full with " + numClients + " people in the room.",
@@ -138,7 +137,7 @@ io.on("connection", function (socket) {
 });
 
 // Listen for Heroku port, otherwise just use 3000
-var port = process.env.PORT || 443;
+var port = process.env.PORT || 3000;
 http.listen(port, function () {
   console.log("http://localhost:" + port);
 });

--- a/server.js
+++ b/server.js
@@ -94,8 +94,10 @@ io.on("connection", function (socket) {
     }
   });
 
-  socket.on("leave", function (room) {
-    logIt("A client has left the room", room);
+  // Client is disconnecting from the server
+  socket.on('disconnecting', () => {
+    var room = Object.keys(socket.rooms).filter(item => item != socket.id); // Socket joins a room of itself, remove that
+    logIt("A client has disconnected from the room", room);
     socket.broadcast.to(room).emit("leave", socket.id);
   });
 

--- a/server.js
+++ b/server.js
@@ -8,6 +8,7 @@ var twillioAccountSID =
 var twilio = require("twilio")(twillioAccountSID, twillioAuthToken);
 var express = require("express");
 var app = express();
+const fs = require('fs');
 var http = require("http").createServer(app);
 var io = require("socket.io")(http);
 var path = require("path");
@@ -80,9 +81,9 @@ io.on("connection", function (socket) {
       socket.join(room);
     } else if (numClients < 5) {
       socket.join(room);
-      // When the client is not the first to join the room, all clients are ready.
-      logIt("Broadcasting ready message", room);
-      socket.broadcast.to(room).emit("willInitiateCall", socket.id, room);
+      logIt("Broadcasting request to connect with new peer...", room);
+      // Emits message to ask peers in room to connect with joining peer
+      socket.broadcast.to(room).emit("initiateCall", socket.id, room);
     } else {
       logIt(
         "room already full with " + numClients + " people in the room.",
@@ -132,7 +133,7 @@ io.on("connection", function (socket) {
 });
 
 // Listen for Heroku port, otherwise just use 3000
-var port = process.env.PORT || 3000;
+var port = process.env.PORT || 443;
 http.listen(port, function () {
   console.log("http://localhost:" + port);
 });

--- a/server.js
+++ b/server.js
@@ -9,11 +9,11 @@ var twilio = require("twilio")(twillioAccountSID, twillioAuthToken);
 var express = require("express");
 var app = express();
 const fs = require('fs');
-// var http = require("https").createServer({
-//   key: fs.readFileSync('/Users/khushjammu/certs/privkey.pem'),
-//   cert: fs.readFileSync('/Users/khushjammu/certs/cert.pem')
-// }, app);
-var http = require("http").createServer(app);
+var http = require("https").createServer({
+  key: fs.readFileSync('/Users/khushjammu/certs/privkey.pem'),
+  cert: fs.readFileSync('/Users/khushjammu/certs/cert.pem')
+}, app);
+// var http = require("http").createServer(app);
 var io = require("socket.io")(http);
 var path = require("path");
 var public = path.join(__dirname, "public");
@@ -92,7 +92,7 @@ io.on("connection", function (socket) {
           // Existing callers initiates call with user
         }
       });
-    } else if (numClients < 3) {
+    } else if (numClients < 4) {
       socket.join(room);
       logIt("Connected clients", room)
       for (var clientId in clients.sockets) {
@@ -145,7 +145,7 @@ io.on("connection", function (socket) {
 });
 
 // Listen for Heroku port, otherwise just use 3000
-var port = process.env.PORT || 3000;
+var port = process.env.PORT || 443;
 http.listen(port, function () {
   console.log("http://localhost:" + port);
 });

--- a/server.js
+++ b/server.js
@@ -9,10 +9,6 @@ var twilio = require("twilio")(twillioAccountSID, twillioAuthToken);
 var express = require("express");
 var app = express();
 const fs = require("fs");
-// var http = require("https").createServer({
-//   key: fs.readFileSync('/Users/khushjammu/certs/privkey.pem'),
-//   cert: fs.readFileSync('/Users/khushjammu/certs/cert.pem')
-// }, app);
 var http = require("http").createServer(app);
 var io = require("socket.io")(http);
 var path = require("path");
@@ -83,22 +79,8 @@ io.on("connection", function (socket) {
     var numClients = typeof clients !== "undefined" ? clients.length : 0;
     if (numClients === 0) {
       socket.join(room);
-      twilio.tokens.create(function (err, response) {
-        if (err) {
-          logIt(err, room);
-        } else {
-          logIt("Token generated. Returning it to the browser client", room);
-          socket.emit("token", response);
-          // Existing callers initiates call with user
-        }
-      });
     } else if (numClients < 5) {
       socket.join(room);
-      logIt("Connected clients", room);
-      for (var clientId in clients.sockets) {
-        logIt("ID: " + clientId, room);
-      }
-
       // When the client is not the first to join the room, all clients are ready.
       logIt("Broadcasting ready message", room);
       socket.broadcast.to(room).emit("willInitiateCall", socket.id, room);

--- a/server.js
+++ b/server.js
@@ -96,17 +96,7 @@ io.on("connection", function (socket) {
 
       // When the client is not the first to join the room, all clients are ready.
       logIt("Broadcasting ready message", room);
-
-      twilio.tokens.create(function (err, response) {
-        if (err) {
-          logIt(err, room);
-        } else {
-          logIt("Token generated. Returning it to the browser client", room);
-          socket.emit("token", response);
-          // Existing callers initiates call with user
-          socket.broadcast.to(room).emit("willInitiateCall", socket.id, room);
-        }
-      });
+      socket.broadcast.to(room).emit("willInitiateCall", socket.id, room);
       // socket.emit("uuid", socket.id);
       socket.emit("ready", room).to(room);
       socket.broadcast.to(room).emit("ready", room);
@@ -118,14 +108,14 @@ io.on("connection", function (socket) {
 
   // When receiving the token message, use the Twilio REST API to request an
   // token to get ephemeral credentials to use the TURN server.
-  socket.on("token", function (room) {
+  socket.on("token", function (room, uuid) {
     logIt("Received token request", room);
     twilio.tokens.create(function (err, response) {
       if (err) {
         logIt(err, room);
       } else {
         logIt("Token generated. Returning it to the browser client", room);
-        socket.emit("token", response);
+        socket.emit("token", response, uuid);
       }
     });
   });

--- a/server.js
+++ b/server.js
@@ -8,7 +8,7 @@ var twillioAccountSID =
 var twilio = require("twilio")(twillioAccountSID, twillioAuthToken);
 var express = require("express");
 var app = express();
-const fs = require('fs');
+const fs = require("fs");
 // var http = require("https").createServer({
 //   key: fs.readFileSync('/Users/khushjammu/certs/privkey.pem'),
 //   cert: fs.readFileSync('/Users/khushjammu/certs/cert.pem')
@@ -94,9 +94,9 @@ io.on("connection", function (socket) {
       });
     } else if (numClients < 4) {
       socket.join(room);
-      logIt("Connected clients", room)
+      logIt("Connected clients", room);
       for (var clientId in clients.sockets) {
-        logIt('ID: ' + clientId, room);
+        logIt("ID: " + clientId, room);
       }
 
       // When the client is not the first to join the room, all clients are ready.
@@ -106,7 +106,10 @@ io.on("connection", function (socket) {
       socket.emit("ready", room).to(room);
       socket.broadcast.to(room).emit("ready", room);
     } else {
-      logIt("room already full with " + numClients + " people in the room.", room);
+      logIt(
+        "room already full with " + numClients + " people in the room.",
+        room
+      );
       socket.emit("full", room);
     }
   });
@@ -133,13 +136,19 @@ io.on("connection", function (socket) {
 
   // Relay offers
   socket.on("offer", function (offer, room, uuid) {
-    logIt("Received offer from " + socket.id + " and emitting to " + uuid, room);
+    logIt(
+      "Received offer from " + socket.id + " and emitting to " + uuid,
+      room
+    );
     io.to(uuid).emit("offer", offer, socket.id);
   });
 
   // Relay answers
   socket.on("answer", function (answer, room, uuid) {
-    logIt("Received answer from " + socket.id + " and emitting to " + uuid, room);
+    logIt(
+      "Received answer from " + socket.id + " and emitting to " + uuid,
+      room
+    );
     io.to(uuid).emit("answer", answer, socket.id);
   });
 });


### PR DESCRIPTION
We've added support for peer-to-peer group video calls for 4 peers, as requested in the linked issue. This is implemented by using multiple RTCPeerConnections per VideoChat client.

The group call actually works, and is done! We are currently just making some small fixes / improvements.

@ianramzy we'd be happy to help load test this and figure out what an appropriate upper bound for group call size should be, although we bet 4 is a good limit.

### CSS fixes
- [x]  Assigning each user a random color for use as border around user's video and displaying in chat
- [ ]  Scaling for screensharing
- [ ]  Video tile wrapping for 3, 4, 5 peers
- [ ]  Adjust video tile size for 2 peer calls
- [ ]  Wrapping tiles for mobile

### Logic fixes
- [x]  Mute mic
- [x]  Fix picture-in-picture
- [ ]  Experiment with downscaling stream quality with 4/5 peers
- [x]  Distinguish between network disconnects and peer leaving room
- [x]  Disabling local video stops peers from connecting
- [x]  Fix peer joining when screensharing
- [ ]  Add check so that it doesn't crash if you send a message when someone is joining

### Testing
- [ ]  Check for random refreshes
- [ ]  Load testing

By:
@taixhi @khushjammu @aryavohra